### PR TITLE
amber_minimise cuda default platform

### DIFF
--- a/alphafold/relax/amber_minimize.py
+++ b/alphafold/relax/amber_minimize.py
@@ -90,7 +90,7 @@ def _openmm_minimize(
     _add_restraints(system, pdb, stiffness, restraint_set, exclude_residues)
 
   integrator = openmm.LangevinIntegrator(0, 0.01, 0.0)
-  platform = openmm.Platform.getPlatformByName("CPU")
+  platform = openmm.Platform.getPlatformByName("CUDA")
   simulation = openmm_app.Simulation(
       pdb.topology, system, integrator, platform)
   simulation.context.setPositions(pdb.positions)
@@ -530,7 +530,7 @@ def get_initial_energies(pdb_strs: Sequence[str],
   simulation = openmm_app.Simulation(openmm_pdbs[0].topology,
                                      system,
                                      openmm.LangevinIntegrator(0, 0.01, 0.0),
-                                     openmm.Platform.getPlatformByName("CPU"))
+                                     openmm.Platform.getPlatformByName("CUDA"))
   energies = []
   for pdb in openmm_pdbs:
     try:


### PR DESCRIPTION
Updates the default platform for amber relaxation from CPU to GPU.

Currently the program uses CPU as the platform for openmm refinement, which can be computationally heavy. Think 64 cores over many hours for a 2000+ AA complex. As only 8 threads are default for hmmer searches and the neural nets basically require a beefy GPU platform. Using CPU for these steps appears to confusing from a system spec-ing, and compute efficiency POV . 

As users will almost universally have invested in GPU compute, it seems reasonable that "CUDA" should be the default.
closes #193